### PR TITLE
Add dark-themed category selection screen with rounded chips

### DIFF
--- a/app/src/main/java/com/example/factcheckthis/MainActivity.kt
+++ b/app/src/main/java/com/example/factcheckthis/MainActivity.kt
@@ -4,13 +4,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import com.example.factcheckthis.ui.theme.FactCheckThisTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,33 +22,18 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            FactCheckThisTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+            var selectedCategories by rememberSaveable { mutableStateOf<List<String>?>(null) }
+
+            FactCheckThisTheme(darkTheme = true) {
+                MainScreen(
+                    isFirstLaunch = selectedCategories == null,
+                    onCategoriesSelected = { selectedCategories = it }
+                )
             }
         }
     }
 }
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    FactCheckThisTheme {
-        Greeting("Android")
-    }
-}
 @Composable
 fun MainScreen(
     isFirstLaunch: Boolean,
@@ -53,16 +42,20 @@ fun MainScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Fact Check This", color = Color.White) },
-                backgroundColor = Color.Black
+                title = { Text("Fact Check This") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Black,
+                    titleContentColor = Color.White
+                )
             )
         },
-        backgroundColor = Color(0xFF121212) // dark background
+        containerColor = Color(0xFF121212)
     ) { padding ->
-        Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(padding)) {
-
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
             if (isFirstLaunch) {
                 CategorySelectionScreen(onCategoriesSelected)
             } else {
@@ -71,3 +64,75 @@ fun MainScreen(
         }
     }
 }
+
+@Composable
+fun CategorySelectionScreen(onCategoriesSelected: (List<String>) -> Unit) {
+    val categories = listOf(
+        "Science" to "🔬",
+        "Space" to "🚀",
+        "History" to "📜",
+        "Sports" to "🏅",
+        "Animals" to "🐾",
+        "Hunting" to "🏹",
+        "Racing" to "🏁",
+        "Weird" to "🌀"
+    )
+    var selected by remember { mutableStateOf(setOf<String>()) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Choose 3 categories", color = Color.White)
+        Spacer(modifier = Modifier.height(16.dp))
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            items(categories) { (name, emoji) ->
+                val isSelected = name in selected
+                FilterChip(
+                    selected = isSelected,
+                    onClick = {
+                        selected = if (isSelected) {
+                            selected - name
+                        } else {
+                            if (selected.size < 3) selected + name else selected
+                        }
+                    },
+                    label = { Text("$emoji $name") },
+                    shape = RoundedCornerShape(50),
+                    colors = FilterChipDefaults.filterChipColors(
+                        containerColor = Color.DarkGray,
+                        labelColor = Color.White,
+                        selectedContainerColor = Color.Gray,
+                        selectedLabelColor = Color.White
+                    ),
+                    modifier = Modifier
+                        .padding(vertical = 4.dp)
+                        .fillMaxWidth(0.8f)
+                )
+            }
+        }
+        Button(
+            onClick = { onCategoriesSelected(selected.toList()) },
+            enabled = selected.size == 3,
+            shape = RoundedCornerShape(50)
+        ) {
+            Text("Continue")
+        }
+    }
+}
+
+@Composable
+fun FactOfTheDayScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Fact of the Day", color = Color.White)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Show category selection on first launch with emojis and rounded chips
- Limit users to picking exactly three categories before continuing
- Apply consistent dark theme styling with rounded buttons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0a16dd588322914a73ea41641f8b